### PR TITLE
31 change osbervable names itemsession obs name to sessionitem obs name

### DIFF
--- a/torch_choice/data/choice_dataset.py
+++ b/torch_choice/data/choice_dataset.py
@@ -239,15 +239,6 @@ class ChoiceDataset(torch.utils.data.Dataset):
             # infer the number of sessions from session_index.
             return len(torch.unique(self.session_index))
 
-        # if self.session_index is None:
-        #     return 1
-
-        # for key, val in self.__dict__.items():
-        #     if torch.is_tensor(val):
-        #         if self._is_session_attribute(key) or self._is_price_attribute(key):
-        #             return val.shape[0]
-        # return 1
-
     @property
     def x_dict(self) -> Dict[object, torch.Tensor]:
         """Formats attributes of in this dataset into shape (num_sessions, num_items, num_params) and returns in a dictionary format.

--- a/torch_choice/data/choice_dataset.py
+++ b/torch_choice/data/choice_dataset.py
@@ -370,7 +370,7 @@ class ChoiceDataset(torch.utils.data.Dataset):
 
     @staticmethod
     def _is_useritem_attribute(key: str) -> bool:
-        return key.startswith('useritem_')
+        return key.startswith('useritem_') or key.startswith('itemuser_')
 
     @staticmethod
     def _is_session_attribute(key: str) -> bool:
@@ -378,11 +378,13 @@ class ChoiceDataset(torch.utils.data.Dataset):
 
     @staticmethod
     def _is_price_attribute(key: str) -> bool:
-        return key.startswith('price_') or key.startswith('itemsession_')
+        return key.startswith('price_') or key.startswith('itemsession_') or key.startswith('sessionitem_')
 
     @staticmethod
     def _is_usersessionitem_attribute(key: str) -> bool:
-        return key.startswith('usersessionitem_')
+        return key.startswith('usersessionitem_') or key.startswith('useritemsession_') \
+            or key.startswith('itemusersession_') or key.startswith('itemsessionuser_') \
+            or key.startswith('sessionuseritem_') or key.startswith('sessionitemuser_')
 
     def _is_attribute(self, key: str) -> bool:
         return self._is_item_attribute(key) \
@@ -391,7 +393,6 @@ class ChoiceDataset(torch.utils.data.Dataset):
             or self._is_session_attribute(key) \
             or self._is_price_attribute(key) \
             or self._is_usersessionitem_attribute(key)
-
 
     def _expand_tensor(self, key: str, val: torch.Tensor) -> torch.Tensor:
         """Expands attribute tensor to (len(self), num_items, num_params) shape for prediction tasks, this method


### PR DESCRIPTION
The `ChoiceDataset` data structure uses keyword argument prefixes to determine the dependency of observable tensors, for example, the `ChoiceDataset` considers `item_price` as an item-specific observable tensor. For observable tensors depending on multiple dimensions (e.g., item-session-specific observable), the requirement on the prefix was strict in previous versions: `itemsession_obs` would work, but `sessionitem_obs` would not.

This patch implements a more flexible prefix system as the following:
1. There is no change to the observable tensor depending on a single dimension, the item-specific tensor should start with `item_`, the user-specific tensor should start with `user_`, and the session-specific tensor should start with `session_`.
2. For tensor depending on two dimensions, denoted `x` and `y` with `x` and `y` from `["item", "user", "session"]`, both prefixes `xy_` and `yx_` would work now. For example, the `ChoiceDataset` would consider tensors with prefix `itemsession_` or `sessionitem_` as (item, session)-specific variable.
3. For tensor depending on all three of item, user, and session, there are six permutations of "item", "user", and "session", all six prefixes (`itemsessionuser_`, 'sessionitemuser_`, etc) would work. 